### PR TITLE
Add Verein inquiry form and Sentry raffle to today page

### DIFF
--- a/public/images/partners/remotion.svg
+++ b/public/images/partners/remotion.svg
@@ -1,0 +1,4 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" rx="40" fill="#0B84F3"/>
+  <polygon points="75,50 75,150 155,100" fill="white"/>
+</svg>

--- a/public/images/partners/supabase.svg
+++ b/public/images/partners/supabase.svg
@@ -1,0 +1,15 @@
+<svg width="200" height="200" viewBox="0 0 109 113" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627H99.1935C108.244 40.0627 113.303 50.5228 107.676 57.3984L63.7076 110.284Z" fill="url(#paint0_linear)"/>
+  <path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627H99.1935C108.244 40.0627 113.303 50.5228 107.676 57.3984L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+  <path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C0.780607 72.2922 -4.27865 61.8321 1.34862 54.9565L45.317 2.07103Z" fill="#3ECF8E"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#249361"/>
+      <stop offset="1" stop-color="#3ECF8E"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
+      <stop/>
+      <stop offset="1" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/today/SentryRaffle.tsx
+++ b/src/components/today/SentryRaffle.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+const RAFFLE_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSfagfGCT9WqKSuUhepz3akRjRi0MH6RNq_ZTTenwBXi-flYYA/viewform?usp=header';
+
+export default function SentryRaffle() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Image
+          src="/images/partners/sentry.png"
+          alt="Sentry logo"
+          width={32}
+          height={32}
+          className="object-contain"
+        />
+        <h2 className="text-lg font-bold text-gray-900">
+          Sentry Raffle
+        </h2>
+      </div>
+
+      <p className="text-sm text-gray-600">
+        Enter the raffle for a chance to win prizes from Sentry! Fill out the form below to participate.
+      </p>
+
+      <Link
+        href={RAFFLE_FORM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full bg-[#362D59] text-white font-bold py-4 px-8 rounded-2xl text-center hover:bg-[#2b2347] transition-colors duration-200"
+      >
+        Enter the Raffle
+      </Link>
+    </div>
+  );
+}

--- a/src/components/today/VereinInquiry.tsx
+++ b/src/components/today/VereinInquiry.tsx
@@ -4,16 +4,32 @@ export default function VereinInquiry() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const subject = encodeURIComponent('ZurichJS Verein Membership Inquiry');
-    const body = encodeURIComponent(
-      `Name: ${name}\nEmail: ${email}\n\n${message || 'I would like to learn more about ZurichJS Verein membership.'}`
-    );
-    window.open(`mailto:hello@zurichjs.com?subject=${subject}&body=${body}`, '_self');
-    setSubmitted(true);
+    setSubmitting(true);
+    setError('');
+
+    try {
+      const res = await fetch('/api/verein-inquiry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to submit');
+      }
+
+      setSubmitted(true);
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -32,13 +48,17 @@ export default function VereinInquiry() {
 
       {submitted ? (
         <div className="bg-green-50 border border-green-200 rounded-2xl p-4 text-center">
-          <p className="text-green-800 font-semibold">Your email client should open shortly!</p>
+          <p className="text-green-800 font-semibold">Inquiry sent!</p>
           <p className="text-green-600 text-sm mt-1">
-            If it didn&apos;t open, email us at{' '}
-            <a href="mailto:hello@zurichjs.com" className="underline">hello@zurichjs.com</a>
+            We&apos;ll get back to you soon.
           </p>
           <button
-            onClick={() => setSubmitted(false)}
+            onClick={() => {
+              setSubmitted(false);
+              setName('');
+              setEmail('');
+              setMessage('');
+            }}
             className="mt-3 text-sm text-green-700 underline"
           >
             Send another inquiry
@@ -90,11 +110,16 @@ export default function VereinInquiry() {
             />
           </div>
 
+          {error && (
+            <p className="text-red-600 text-sm">{error}</p>
+          )}
+
           <button
             type="submit"
-            className="w-full bg-black text-white font-bold py-4 px-8 rounded-2xl hover:bg-black/90 transition-colors duration-200"
+            disabled={submitting}
+            className="w-full bg-black text-white font-bold py-4 px-8 rounded-2xl hover:bg-black/90 transition-colors duration-200 disabled:opacity-50"
           >
-            Send Inquiry
+            {submitting ? 'Sending...' : 'Send Inquiry'}
           </button>
         </form>
       )}

--- a/src/components/today/VereinInquiry.tsx
+++ b/src/components/today/VereinInquiry.tsx
@@ -1,0 +1,103 @@
+import { useState, FormEvent } from 'react';
+
+export default function VereinInquiry() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const subject = encodeURIComponent('ZurichJS Verein Membership Inquiry');
+    const body = encodeURIComponent(
+      `Name: ${name}\nEmail: ${email}\n\n${message || 'I would like to learn more about ZurichJS Verein membership.'}`
+    );
+    window.open(`mailto:hello@zurichjs.com?subject=${subject}&body=${body}`, '_self');
+    setSubmitted(true);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-2xl">🇨🇭</span>
+          <h2 className="text-lg font-bold text-gray-900">
+            ZurichJS is now a Verein!
+          </h2>
+        </div>
+        <p className="text-sm text-gray-600">
+          We are officially registered as a Swiss Verein (association). Interested in becoming a member or learning more? Send us an inquiry!
+        </p>
+      </div>
+
+      {submitted ? (
+        <div className="bg-green-50 border border-green-200 rounded-2xl p-4 text-center">
+          <p className="text-green-800 font-semibold">Your email client should open shortly!</p>
+          <p className="text-green-600 text-sm mt-1">
+            If it didn&apos;t open, email us at{' '}
+            <a href="mailto:hello@zurichjs.com" className="underline">hello@zurichjs.com</a>
+          </p>
+          <button
+            onClick={() => setSubmitted(false)}
+            className="mt-3 text-sm text-green-700 underline"
+          >
+            Send another inquiry
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="verein-name" className="block text-sm font-medium text-gray-700 mb-1">
+              Name
+            </label>
+            <input
+              id="verein-name"
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-black focus:outline-none transition-colors"
+              placeholder="Your name"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="verein-email" className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
+            <input
+              id="verein-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-black focus:outline-none transition-colors"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="verein-message" className="block text-sm font-medium text-gray-700 mb-1">
+              Message <span className="text-gray-400">(optional)</span>
+            </label>
+            <textarea
+              id="verein-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={3}
+              className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-black focus:outline-none transition-colors resize-none"
+              placeholder="Tell us about your interest..."
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full bg-black text-white font-bold py-4 px-8 rounded-2xl hover:bg-black/90 transition-colors duration-200"
+          >
+            Send Inquiry
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -150,11 +150,31 @@ export const getPartners = () => {
             id: '19',
             name: 'Stripe',
             logo: '/images/partners/stripe.png',
-            url: 'https://forms.gle/9LN2tnmm9JubThgTA', // TODO: temp fix for current meetup
+            url: 'https://stripe.com',
             type: 'supporting',
             sponsorshipTier: 'builder',
             description: 'Financial infrastructure for the internet',
             blurb: 'Stripe is a financial infrastructure platform for businesses. Millions of companies use Stripe to accept payments, grow revenue, and accelerate new business opportunities.'
+        },
+        {
+            id: '20',
+            name: 'Supabase',
+            logo: '/images/partners/supabase.svg',
+            url: 'https://supabase.com',
+            type: 'supporting',
+            sponsorshipTier: 'builder',
+            description: 'The open source Firebase alternative',
+            blurb: 'Supabase is an open source Firebase alternative. Start your project with a Postgres database, Authentication, instant APIs, Edge Functions, Realtime subscriptions, Storage, and Vector embeddings.'
+        },
+        {
+            id: '21',
+            name: 'Remotion',
+            logo: '/images/partners/remotion.svg',
+            url: 'https://remotion.dev',
+            type: 'supporting',
+            sponsorshipTier: 'friend',
+            description: 'Make videos programmatically with React',
+            blurb: 'Remotion is a framework for creating videos programmatically using React. Write video templates in React, render them using Node.js or in the cloud.'
         },
     ];
 
@@ -194,29 +214,39 @@ export interface TodaySponsor {
 export const getTodaysSponsors = (): TodaySponsor[] => {
     // Get existing partners for sponsors that are already in our system
     const allPartners = getPartners();
-    const getYourGuide = allPartners.find(p => p.name === 'Get Your Guide');
-    const stripe = allPartners.find(p => p.name === 'Stripe');
+    const supabase = allPartners.find(p => p.name === 'Supabase');
+    const remotion = allPartners.find(p => p.name === 'Remotion');
     const gyff = allPartners.find(p => p.name === 'GYFF');
+    const sentry = allPartners.find(p => p.name === 'Sentry');
 
     const sponsors: TodaySponsor[] = [
         // Community Builder tier (Gold sponsor)
-        ...(stripe ? [{
-            id: stripe.id,
-            name: stripe.name,
-            logo: stripe.logo,
-            url: stripe.url,
+        ...(supabase ? [{
+            id: supabase.id,
+            name: supabase.name,
+            logo: supabase.logo,
+            url: supabase.url,
             tier: 'builder' as const,
-            description: stripe.description
+            description: supabase.description
         }] : []),
 
-        // Community Friend tier (Venue sponsor)
-        ...(getYourGuide ? [{
-            id: getYourGuide.id,
-            name: getYourGuide.name,
-            logo: getYourGuide.logo,
-            url: getYourGuide.url,
+        // Community Friend tier
+        ...(remotion ? [{
+            id: remotion.id,
+            name: remotion.name,
+            logo: remotion.logo,
+            url: remotion.url,
             tier: 'friend' as const,
-            description: 'Venue sponsor for this event'
+            description: remotion.description
+        }] : []),
+
+        ...(sentry ? [{
+            id: sentry.id,
+            name: sentry.name,
+            logo: sentry.logo,
+            url: sentry.url,
+            tier: 'friend' as const,
+            description: sentry.description
         }] : []),
 
         // Community Supporter tier

--- a/src/pages/api/verein-inquiry.ts
+++ b/src/pages/api/verein-inquiry.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { sendPlatformNotification } from '@/lib/notification';
+
+type ResponseData = {
+  success: boolean;
+  message: string;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, message: 'Method not allowed' });
+  }
+
+  try {
+    const { name, email, message } = req.body;
+
+    if (!name || !email) {
+      return res.status(400).json({
+        success: false,
+        message: 'Missing required fields'
+      });
+    }
+
+    await sendPlatformNotification({
+      title: `New Verein Membership Inquiry`,
+      message: `Name: ${name}\nEmail: ${email}\nMessage: ${message || 'No message provided'}`,
+      priority: 0
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: 'Verein inquiry submitted successfully'
+    });
+  } catch (error) {
+    console.error('Verein inquiry error:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to submit inquiry'
+    });
+  }
+}
+
+export default handler;

--- a/src/pages/today.tsx
+++ b/src/pages/today.tsx
@@ -6,10 +6,12 @@ import Header from '@/components/layout/Header';
 import Section from '@/components/Section';
 import SEO from '@/components/SEO';
 import ScheduleCard from '@/components/today/ScheduleCard';
+import SentryRaffle from '@/components/today/SentryRaffle';
 import StickyActions from '@/components/today/StickyActions';
 import TodayCard from '@/components/today/TodayCard';
 import TodayHero from '@/components/today/TodayHero';
 import TodaysSponsors from '@/components/today/TodaysSponsors';
+import VereinInquiry from '@/components/today/VereinInquiry';
 import { Event, getEventById } from '@/sanity/queries';
 
 interface TodayPageProps {
@@ -157,6 +159,30 @@ export default function TodayPage({ upcomingEvent }: TodayPageProps) {
               <TodaysSponsors />
             </TodayCard>
           </motion.div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <motion.div
+              initial={isClient ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.25 }}
+              data-section="raffle"
+            >
+              <TodayCard className="h-full">
+                <SentryRaffle />
+              </TodayCard>
+            </motion.div>
+
+            <motion.div
+              initial={isClient ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.3 }}
+              data-section="verein"
+            >
+              <TodayCard className="h-full">
+                <VereinInquiry />
+              </TodayCard>
+            </motion.div>
+          </div>
       </div>
 
       {/* Sticky actions */}
@@ -168,7 +194,7 @@ export default function TodayPage({ upcomingEvent }: TodayPageProps) {
 
 export async function getStaticProps() {
   try {
-    const upcomingEvent = await getEventById('jan-2026');
+    const upcomingEvent = await getEventById('feb-2026');
 
     return {
       props: {


### PR DESCRIPTION
## Summary
This PR adds two new interactive components to the today/event page and updates the sponsors list with new partners.

## Key Changes

- **New Components**:
  - `VereinInquiry`: A form component that allows users to inquire about ZurichJS Verein membership. The form captures name, email, and optional message, then opens the user's email client with a pre-filled inquiry email to hello@zurichjs.com.
  - `SentryRaffle`: A raffle entry component that links to a Google Form for users to participate in a Sentry raffle.

- **Updated Sponsors Data**:
  - Added two new partners: Supabase (builder tier) and Remotion (friend tier)
  - Fixed Stripe's URL from a temporary Google Form to the actual Stripe website
  - Updated `getTodaysSponsors()` to feature Supabase and Remotion instead of Get Your Guide and Stripe, and added Sentry as a featured sponsor

- **Today Page Updates**:
  - Integrated both new components into the today page layout in a two-column grid
  - Updated the event reference from 'jan-2026' to 'feb-2026'
  - Added proper animations and styling consistent with existing TodayCard components

- **Assets**:
  - Added SVG logos for Supabase and Remotion partners

## Implementation Details

The VereinInquiry form uses React hooks for state management and constructs a mailto link with encoded subject and body parameters. After submission, it displays a success message with an option to send another inquiry. The form includes proper accessibility with labeled inputs and required field validation.

The SentryRaffle component is a simple link wrapper with Sentry branding that directs users to an external Google Form for raffle entry.

https://claude.ai/code/session_017xjKQDxwhktbRjNu9cqr7Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public POST API (`/api/verein-inquiry`) that forwards user-provided content into platform notifications; this can introduce spam/abuse risk without rate limiting/validation. Remaining changes are UI/content updates and sponsor data tweaks.
> 
> **Overview**
> Adds two new Today-page cards: `SentryRaffle` (external Google Form link) and `VereinInquiry` (client form that POSTs to a new `/api/verein-inquiry` endpoint).
> 
> Introduces the `/api/verein-inquiry` route which validates required fields and sends the inquiry via `sendPlatformNotification`.
> 
> Updates sponsor data by fixing Stripe’s URL, adding Supabase and Remotion (with new SVG logos), and changing `getTodaysSponsors()` to feature Supabase/Remotion/Sentry; also switches `today.tsx` to load `feb-2026` instead of `jan-2026`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72b28ababd1701767c5ea0f845e5452ec76f28a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->