### PR TITLE
Fix workshop page auto-scroll and sticky banner overlapping header

### DIFF
--- a/src/components/workshop/TicketSelection.tsx
+++ b/src/components/workshop/TicketSelection.tsx
@@ -56,6 +56,7 @@ export default function TicketSelection({
   // Ref for payment buttons section
   const paymentButtonsRef = useRef<HTMLDivElement>(null);
   const [highlightButtons, setHighlightButtons] = useState(false);
+  const hasUserInteracted = useRef(false);
   
   const { startCheckout, isLoading, isSignedIn } = useAuthenticatedCheckout({
     onError: (error) => {
@@ -68,9 +69,9 @@ export default function TicketSelection({
   const hasCoupon = couponData && couponData.isValid;
   const communityDiscount = isSignedIn && !hasCoupon;
 
-  // Scroll to payment buttons and highlight when ticket is selected
+  // Scroll to payment buttons and highlight when ticket is selected (skip auto-selected on mount)
   useEffect(() => {
-    if (selectedTicket && paymentButtonsRef.current) {
+    if (selectedTicket && paymentButtonsRef.current && hasUserInteracted.current) {
       // Scroll to payment buttons with center alignment
       paymentButtonsRef.current.scrollIntoView({
         behavior: 'smooth',
@@ -207,7 +208,7 @@ export default function TicketSelection({
           }`}
         >
           <button
-            onClick={() => setSelectedTicket(getPriceId(ticket))}
+            onClick={() => { hasUserInteracted.current = true; setSelectedTicket(getPriceId(ticket)); }}
             className="w-full text-left"
           >
             <div className="flex flex-col space-y-4">

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -315,7 +315,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
             />
 
             {/* Sticky Info Banner */}
-            <div className="sticky top-0 z-30 bg-zurich text-white shadow-lg">
+            <div className="sticky top-16 lg:top-20 z-30 bg-zurich text-white shadow-lg">
                 <div className="container mx-auto px-3 sm:px-4 py-2 sm:py-3">
                     <div className="flex flex-col sm:flex-row items-center justify-between gap-2 sm:gap-4">
                         <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4 text-center sm:text-left w-full sm:w-auto">


### PR DESCRIPTION
- Prevent TicketSelection from scrolling to payment buttons on initial
  mount when a ticket is auto-selected; only scroll after user interaction
- Position the workshop sticky info banner below the header (top-16/top-20)
  instead of top-0, so it no longer overlaps the fixed header and blocks
  the logo home link

https://claude.ai/code/session_01TBSR3ixbvCZrtRSWypTvFg