### PR TITLE
Update AI agents workshop to show 2 seats remaining

### DIFF
--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -43,7 +43,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
     const workshopTime = '17:00 - 18:30 (1.5 hours)';
     const workshopLocation = 'Smallpdf AG, Zürich';
     const totalSeats = 20;
-    const seatsRemaining = totalSeats;
+    const seatsRemaining = 2;
     const isSoldOut = seatsRemaining <= 0;
 
     const topics = [


### PR DESCRIPTION
Updates the reliable AI agents workshop page to indicate only 2 seats
are still available, reflecting near sold-out status.

https://claude.ai/code/session_01BANo6k4jcmbP9Q9CixkgnA