### PR TITLE
Add waitlist for sold-out AI agents workshop

### DIFF
--- a/src/components/workshop/WorkshopWaitlist.tsx
+++ b/src/components/workshop/WorkshopWaitlist.tsx
@@ -1,0 +1,287 @@
+import { useUser } from '@clerk/nextjs';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, AlertCircle, CheckCircle, Mail } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import Button from '@/components/ui/Button';
+import useEvents from '@/hooks/useEvents';
+
+interface WorkshopWaitlistProps {
+  workshopId: string;
+  workshopTitle: string;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function WorkshopWaitlist({ workshopId, workshopTitle }: WorkshopWaitlistProps) {
+  const { user } = useUser();
+  const { track } = useEvents();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isJoined, setIsJoined] = useState(false);
+
+  // Prefill form with Clerk user data when available
+  useEffect(() => {
+    if (user) {
+      if (!email && user.primaryEmailAddress) {
+        setEmail(user.primaryEmailAddress.emailAddress);
+      }
+      if (!name && user.firstName && user.lastName) {
+        setName(`${user.firstName} ${user.lastName}`);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  // Close on escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    if (isOpen) document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen]);
+
+  const openModal = () => {
+    track('waitlist_clicked', { workshop_id: workshopId });
+    setError(null);
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedEmail = email.trim();
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      track('waitlist_submit_attempt', {
+        workshop_id: workshopId,
+        workshop_title: workshopTitle,
+        user_email: trimmedEmail,
+      });
+
+      const response = await fetch('/api/workshops/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workshopId,
+          workshopTitle,
+          email: trimmedEmail,
+          name: name.trim() || undefined,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to join the waitlist');
+      }
+
+      setIsJoined(true);
+      track('waitlist_joined', {
+        workshop_id: workshopId,
+        workshop_title: workshopTitle,
+        user_email: data.email,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to join the waitlist';
+      setError(message);
+      track('waitlist_join_error', {
+        workshop_id: workshopId,
+        workshop_title: workshopTitle,
+        error: message,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const modalContent = (
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 flex items-center justify-center"
+          style={{ zIndex: 9999999 }}
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm"
+            style={{ zIndex: 9999998 }}
+            onClick={closeModal}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 400, duration: 0.3 }}
+            className="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden relative mx-4 sm:mx-0"
+            style={{ zIndex: 9999999 }}
+          >
+            {/* Header */}
+            <div className="bg-gradient-to-r from-violet-600 to-indigo-600 px-5 py-4 flex justify-between items-center">
+              <h2 className="text-lg font-bold text-white flex items-center gap-2">
+                <Mail size={18} />
+                Join the Waitlist
+              </h2>
+              <button
+                onClick={closeModal}
+                className="text-white hover:text-gray-200 focus:outline-none"
+                aria-label="Close"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="p-5">
+              {isJoined ? (
+                <div className="text-center py-4">
+                  <div className="mx-auto w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mb-3">
+                    <CheckCircle className="h-6 w-6 text-green-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re on the list!</h3>
+                  <p className="text-sm text-gray-600 mb-5">
+                    We&apos;ll email <span className="font-medium">{email}</span> if a seat opens up for &quot;{workshopTitle}&quot;.
+                  </p>
+                  <Button
+                    onClick={closeModal}
+                    className="bg-black text-white px-5 py-2 rounded-lg font-semibold text-sm w-full"
+                  >
+                    Close
+                  </Button>
+                </div>
+              ) : (
+                <>
+                  <p className="text-sm text-gray-600 mb-4">
+                    This workshop is sold out. Drop your email and we&apos;ll let you know if a spot opens up for{' '}
+                    <span className="font-semibold text-black">&quot;{workshopTitle}&quot;</span>.
+                  </p>
+
+                  {error && (
+                    <div className="bg-red-50 text-red-700 p-2 rounded-lg border border-red-200 text-xs mb-3 flex items-start">
+                      <AlertCircle className="h-4 w-4 mr-1 flex-shrink-0 mt-0.5" />
+                      <span>{error}</span>
+                    </div>
+                  )}
+
+                  <form onSubmit={handleSubmit} className="space-y-3">
+                    <div>
+                      <label htmlFor="waitlist-email" className="block text-xs font-medium text-gray-700 mb-1">
+                        Email address <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        type="email"
+                        id="waitlist-email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-violet-500 focus:border-violet-500"
+                        placeholder="you@example.com"
+                        required
+                        autoFocus
+                      />
+                    </div>
+
+                    <div>
+                      <label htmlFor="waitlist-name" className="block text-xs font-medium text-gray-700 mb-1">
+                        Name <span className="text-gray-400">(optional)</span>
+                      </label>
+                      <input
+                        type="text"
+                        id="waitlist-name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-violet-500 focus:border-violet-500"
+                        placeholder="Your name"
+                      />
+                    </div>
+
+                    <Button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="w-full bg-violet-600 text-white hover:bg-violet-700 disabled:bg-gray-300 disabled:text-gray-500 py-2.5 rounded-lg font-semibold text-sm"
+                    >
+                      {isSubmitting ? (
+                        <span className="flex items-center justify-center">
+                          <svg
+                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                          Joining...
+                        </span>
+                      ) : (
+                        'Join the Waitlist'
+                      )}
+                    </Button>
+
+                    <p className="text-[11px] text-center text-gray-500">
+                      We&apos;ll only use your email to notify you about this workshop.
+                    </p>
+                  </form>
+                </>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+
+  return (
+    <>
+      <div className="max-w-md mx-auto text-center">
+        <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
+          <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
+          <p className="text-gray-300 text-sm mb-6">
+            {isJoined
+              ? "You're on the waitlist — we'll be in touch if a spot opens up."
+              : "Join the waitlist and we'll notify you if a spot opens up."}
+          </p>
+          {isJoined ? (
+            <div className="bg-green-500/20 text-green-200 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
+              <CheckCircle size={16} />
+              You&apos;re on the list
+            </div>
+          ) : (
+            <Button
+              onClick={openModal}
+              className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
+            >
+              Join Waitlist
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {typeof window !== 'undefined' && createPortal(modalContent, document.body)}
+    </>
+  );
+}

--- a/src/components/workshop/WorkshopWaitlist.tsx
+++ b/src/components/workshop/WorkshopWaitlist.tsx
@@ -133,6 +133,13 @@ export default function WorkshopWaitlist({
     }
   };
 
+  // Reusable class strings that match the workshop page's brand identity
+  // (`bg-black text-js ... rounded-xl` for the hero CTA pattern).
+  const primaryButtonClass =
+    'w-full bg-black text-js font-bold px-6 py-3 rounded-xl hover:bg-gray-900 disabled:bg-gray-300 disabled:text-gray-500 transition-colors';
+  const inputClass =
+    'w-full px-3 py-2 text-sm border-2 border-black/10 rounded-lg bg-white text-black placeholder:text-gray-400 focus:outline-none focus:border-black focus:ring-0 disabled:bg-gray-50 disabled:text-gray-500';
+
   const modalContent = (
     <AnimatePresence>
       {isOpen && (
@@ -145,7 +152,7 @@ export default function WorkshopWaitlist({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 bg-black bg-opacity-60 backdrop-blur-sm"
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm"
             style={{ zIndex: 9999998 }}
             onClick={closeModal}
           />
@@ -155,18 +162,19 @@ export default function WorkshopWaitlist({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ type: 'spring', damping: 25, stiffness: 400, duration: 0.3 }}
-            className="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden relative mx-4 sm:mx-0"
+            className="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden relative mx-4 sm:mx-0 border-2 border-black"
             style={{ zIndex: 9999999 }}
           >
-            {/* Header */}
-            <div className="bg-gradient-to-r from-violet-600 to-indigo-600 px-5 py-4 flex justify-between items-center">
-              <h2 className="text-lg font-bold text-white flex items-center gap-2">
+            {/* Header — matches the workshop hero (bg-js + black) */}
+            <div className="bg-js px-5 py-4 flex justify-between items-center border-b-2 border-black">
+              <h2 className="text-lg font-black text-black flex items-center gap-2">
                 <Mail size={18} />
                 Join the Waitlist
               </h2>
               <button
+                type="button"
                 onClick={closeModal}
-                className="text-white hover:text-gray-200 focus:outline-none"
+                className="text-black hover:text-gray-700 focus:outline-none"
                 aria-label="Close"
               >
                 <X size={20} />
@@ -177,10 +185,12 @@ export default function WorkshopWaitlist({
             <div className="p-5">
               {joinedOutcome === 'walk-in' ? (
                 <div className="text-center py-2">
-                  <div className="mx-auto w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mb-3">
-                    <DoorOpen className="h-6 w-6 text-green-600" />
+                  <div className="mx-auto w-12 h-12 rounded-full bg-js flex items-center justify-center mb-3 border-2 border-black">
+                    <DoorOpen className="h-6 w-6 text-black" />
                   </div>
-                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re in — show up at the door!</h3>
+                  <h3 className="text-lg font-black text-black mb-2">
+                    You&apos;re in — show up at the door!
+                  </h3>
                   <p className="text-sm text-gray-700 mb-3">
                     We have a small overbooking buffer and you fit in it. Just{' '}
                     <span className="font-semibold">come to the workshop</span> and pay{' '}
@@ -190,54 +200,48 @@ export default function WorkshopWaitlist({
                     We&apos;ve also sent ourselves a note with your email{' '}
                     (<span className="font-medium">{email}</span>) in case anything changes.
                   </p>
-                  <Button
-                    onClick={closeModal}
-                    className="bg-black text-white px-5 py-2 rounded-lg font-semibold text-sm w-full"
-                  >
+                  <Button onClick={closeModal} className={primaryButtonClass}>
                     Got it
                   </Button>
                 </div>
               ) : joinedOutcome === 'email-when-available' ? (
                 <div className="text-center py-2">
-                  <div className="mx-auto w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center mb-3">
-                    <Clock className="h-6 w-6 text-blue-600" />
+                  <div className="mx-auto w-12 h-12 rounded-full bg-zurich flex items-center justify-center mb-3">
+                    <Clock className="h-6 w-6 text-white" />
                   </div>
-                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re on the waitlist</h3>
+                  <h3 className="text-lg font-black text-black mb-2">You&apos;re on the waitlist</h3>
                   <p className="text-sm text-gray-700 mb-5">
                     The room is full. We&apos;ll email{' '}
                     <span className="font-medium">{email}</span> if a seat opens up — usually
                     a day or two before the workshop.
                   </p>
-                  <Button
-                    onClick={closeModal}
-                    className="bg-black text-white px-5 py-2 rounded-lg font-semibold text-sm w-full"
-                  >
+                  <Button onClick={closeModal} className={primaryButtonClass}>
                     Close
                   </Button>
                 </div>
               ) : (
                 <>
                   {nextOutcome === 'walk-in' ? (
-                    <div className="bg-green-50 border border-green-200 rounded-lg p-3 mb-4 text-xs text-green-900 flex items-start gap-2">
-                      <DoorOpen className="h-4 w-4 mt-0.5 flex-shrink-0 text-green-600" />
+                    <div className="bg-js/40 border-2 border-black rounded-xl p-3 mb-4 text-xs text-black flex items-start gap-2">
+                      <DoorOpen className="h-4 w-4 mt-0.5 flex-shrink-0 text-black" />
                       <span>
                         Tickets are sold out, but we have room for a few more. If you sign up now,
-                        you can <span className="font-semibold">show up at the door and pay CHF 35 in cash</span>.
+                        you can <span className="font-bold">show up at the door and pay CHF 35 in cash</span>.
                       </span>
                     </div>
                   ) : (
-                    <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4 text-xs text-blue-900 flex items-start gap-2">
-                      <Clock className="h-4 w-4 mt-0.5 flex-shrink-0 text-blue-600" />
+                    <div className="bg-zurich/10 border-2 border-zurich rounded-xl p-3 mb-4 text-xs text-zurich flex items-start gap-2">
+                      <Clock className="h-4 w-4 mt-0.5 flex-shrink-0 text-zurich" />
                       <span>
                         The room is full. Drop your email and{' '}
-                        <span className="font-semibold">we&apos;ll reach out</span> if a seat opens up.
+                        <span className="font-bold">we&apos;ll reach out</span> if a seat opens up.
                       </span>
                     </div>
                   )}
 
                   {/* Sign-in option for guests */}
                   {isLoaded && !isSignedIn && (
-                    <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 mb-4 flex items-center justify-between gap-3">
+                    <div className="bg-gray-50 border border-black/10 rounded-xl p-3 mb-4 flex items-center justify-between gap-3">
                       <span className="text-xs text-gray-700">
                         Have an account? Sign in to use your saved email.
                       </span>
@@ -247,7 +251,7 @@ export default function WorkshopWaitlist({
                           onClick={() =>
                             track('waitlist_signin_clicked', { workshop_id: workshopId })
                           }
-                          className="text-xs font-semibold text-violet-700 hover:text-violet-900 whitespace-nowrap"
+                          className="text-xs font-bold text-zurich hover:underline whitespace-nowrap"
                         >
                           Sign in
                         </button>
@@ -264,7 +268,7 @@ export default function WorkshopWaitlist({
 
                   <form onSubmit={handleSubmit} className="space-y-3">
                     <div>
-                      <label htmlFor="waitlist-email" className="block text-xs font-medium text-gray-700 mb-1">
+                      <label htmlFor="waitlist-email" className="block text-xs font-bold text-black mb-1">
                         Email address <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -272,7 +276,7 @@ export default function WorkshopWaitlist({
                         id="waitlist-email"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
-                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-violet-500 focus:border-violet-500"
+                        className={inputClass}
                         placeholder="you@example.com"
                         required
                         autoFocus
@@ -286,28 +290,24 @@ export default function WorkshopWaitlist({
                     </div>
 
                     <div>
-                      <label htmlFor="waitlist-name" className="block text-xs font-medium text-gray-700 mb-1">
-                        Name <span className="text-gray-400">(optional)</span>
+                      <label htmlFor="waitlist-name" className="block text-xs font-bold text-black mb-1">
+                        Name <span className="font-normal text-gray-500">(optional)</span>
                       </label>
                       <input
                         type="text"
                         id="waitlist-name"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-violet-500 focus:border-violet-500"
+                        className={inputClass}
                         placeholder="Your name"
                       />
                     </div>
 
-                    <Button
-                      type="submit"
-                      disabled={isSubmitting}
-                      className="w-full bg-violet-600 text-white hover:bg-violet-700 disabled:bg-gray-300 disabled:text-gray-500 py-2.5 rounded-lg font-semibold text-sm"
-                    >
+                    <Button type="submit" disabled={isSubmitting} className={primaryButtonClass}>
                       {isSubmitting ? (
                         <span className="flex items-center justify-center">
                           <svg
-                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-js"
                             xmlns="http://www.w3.org/2000/svg"
                             fill="none"
                             viewBox="0 0 24 24"
@@ -345,7 +345,7 @@ export default function WorkshopWaitlist({
     <>
       <div className="max-w-md mx-auto text-center">
         <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
-          <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
+          <h3 className="text-xl font-black text-white mb-3">Workshop Sold Out</h3>
 
           {joinedOutcome ? (
             <>
@@ -354,7 +354,7 @@ export default function WorkshopWaitlist({
                   ? "You're in — show up at the door and pay in cash."
                   : "You're on the waitlist. We'll email you if a seat opens up."}
               </p>
-              <div className="bg-green-500/20 text-green-200 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
+              <div className="bg-js/20 text-js border border-js/40 rounded-xl px-6 py-3 font-bold text-sm flex items-center justify-center gap-2">
                 <CheckCircle size={16} />
                 You&apos;re on the list
               </div>
@@ -368,7 +368,7 @@ export default function WorkshopWaitlist({
               </p>
               <Button
                 onClick={openModal}
-                className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
+                className="w-full bg-js text-black font-bold px-6 py-3 rounded-xl border-2 border-black hover:bg-js-dark transition-colors"
               >
                 Join Waitlist
               </Button>

--- a/src/components/workshop/WorkshopWaitlist.tsx
+++ b/src/components/workshop/WorkshopWaitlist.tsx
@@ -10,11 +10,18 @@ import useEvents from '@/hooks/useEvents';
 interface WorkshopWaitlistProps {
   workshopId: string;
   workshopTitle: string;
+  shouldPayInPerson: boolean;
+  overbookingLimit: number;
 }
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export default function WorkshopWaitlist({ workshopId, workshopTitle }: WorkshopWaitlistProps) {
+export default function WorkshopWaitlist({
+  workshopId,
+  workshopTitle,
+  shouldPayInPerson,
+  overbookingLimit,
+}: WorkshopWaitlistProps) {
   const { user } = useUser();
   const { track } = useEvents();
 
@@ -56,6 +63,16 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  const waitlistIntro = shouldPayInPerson
+    ? `This workshop is sold out, but we can make room for a few extra people up to ${overbookingLimit} attendees. Join the waitlist and show up on the day. You can pay in person.`
+    : 'This workshop is sold out. Join the waitlist and we will reach out by email if a spot opens up.';
+  const waitlistSuccess = shouldPayInPerson
+    ? `You are on the waitlist for "${workshopTitle}". Please show up on the day and you can pay in person.`
+    : `We will email ${email} if a seat opens up for "${workshopTitle}".`;
+  const waitlistSummary = shouldPayInPerson
+    ? "You're on the waitlist. Please show up on the day and pay in person."
+    : "You're on the waitlist. We'll be in touch if a spot opens up.";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -138,18 +155,18 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
             style={{ zIndex: 9999999 }}
           >
             {/* Header */}
-            <div className="bg-gradient-to-r from-violet-600 to-indigo-600 px-5 py-4 flex justify-between items-center">
-              <h2 className="text-lg font-bold text-white flex items-center gap-2">
+            <div className="px-5 py-4 flex justify-between items-center">
+              <h2 className="text-lg font-bold  flex items-center gap-2">
                 <Mail size={18} />
                 Join the Waitlist
               </h2>
-              <button
+              <Button
+                  variant="ghost"
                 onClick={closeModal}
-                className="text-white hover:text-gray-200 focus:outline-none"
                 aria-label="Close"
               >
                 <X size={20} />
-              </button>
+              </Button>
             </div>
 
             {/* Body */}
@@ -160,9 +177,7 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                     <CheckCircle className="h-6 w-6 text-green-600" />
                   </div>
                   <h3 className="text-lg font-bold text-black mb-2">You&apos;re on the list!</h3>
-                  <p className="text-sm text-gray-600 mb-5">
-                    We&apos;ll email <span className="font-medium">{email}</span> if a seat opens up for &quot;{workshopTitle}&quot;.
-                  </p>
+                  <p className="text-sm  mb-5">{waitlistSuccess}</p>
                   <Button
                     onClick={closeModal}
                     className="bg-black text-white px-5 py-2 rounded-lg font-semibold text-sm w-full"
@@ -172,10 +187,7 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                 </div>
               ) : (
                 <>
-                  <p className="text-sm text-gray-600 mb-4">
-                    This workshop is sold out. Drop your email and we&apos;ll let you know if a spot opens up for{' '}
-                    <span className="font-semibold text-black">&quot;{workshopTitle}&quot;</span>.
-                  </p>
+                  <p className="text-sm  mb-4">{waitlistIntro}</p>
 
                   {error && (
                     <div className="bg-red-50 text-red-700 p-2 rounded-lg border border-red-200 text-xs mb-3 flex items-start">
@@ -216,14 +228,14 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                     </div>
 
                     <Button
+                        variant="primary"
                       type="submit"
                       disabled={isSubmitting}
-                      className="w-full bg-violet-600 text-white hover:bg-violet-700 disabled:bg-gray-300 disabled:text-gray-500 py-2.5 rounded-lg font-semibold text-sm"
                     >
                       {isSubmitting ? (
                         <span className="flex items-center justify-center">
                           <svg
-                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                            className="animate-spin -ml-1 mr-2 h-4 w-4 "
                             xmlns="http://www.w3.org/2000/svg"
                             fill="none"
                             viewBox="0 0 24 24"
@@ -259,21 +271,21 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
     <>
       <div className="max-w-md mx-auto text-center">
         <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
-          <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
-          <p className="text-gray-300 text-sm mb-6">
+          <h3 className="text-xl font-bold  mb-3">Workshop Sold Out</h3>
+          <p className="text-sm mb-6">
             {isJoined
-              ? "You're on the waitlist — we'll be in touch if a spot opens up."
-              : "Join the waitlist and we'll notify you if a spot opens up."}
+              ? waitlistSummary
+              : waitlistIntro}
           </p>
           {isJoined ? (
-            <div className="bg-green-500/20 text-green-200 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
+            <div className="bg-green-500/20 text-green-800 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
               <CheckCircle size={16} />
               You&apos;re on the list
             </div>
           ) : (
             <Button
+              variant="primary"
               onClick={openModal}
-              className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
             >
               Join Waitlist
             </Button>

--- a/src/components/workshop/WorkshopWaitlist.tsx
+++ b/src/components/workshop/WorkshopWaitlist.tsx
@@ -82,8 +82,6 @@ export default function WorkshopWaitlist({
       ? "You're on the waitlist. Please show up on the day and pay in person."
       : "You're on the waitlist. We'll be in touch if a spot opens up.";
 
-  const primaryButtonClass =
-    'w-full bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 disabled:bg-gray-300 disabled:text-gray-500 transition-colors';
   const inputClass =
     'w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-black focus:border-black disabled:bg-gray-50 disabled:text-gray-500';
 
@@ -257,7 +255,7 @@ export default function WorkshopWaitlist({
                       />
                     </div>
 
-                    <Button type="submit" disabled={isSubmitting} className={primaryButtonClass}>
+                    <Button variant="primary" type="submit" disabled={isSubmitting}>
                       {isSubmitting ? (
                         <span className="flex items-center justify-center">
                           <svg
@@ -280,7 +278,7 @@ export default function WorkshopWaitlist({
                       )}
                     </Button>
 
-                    <p className="text-[11px] text-center text-gray-500">
+                    <p className="text-xs text-center text-gray-500">
                       We&apos;ll only use your email to contact you about this workshop.
                     </p>
                   </form>
@@ -298,7 +296,7 @@ export default function WorkshopWaitlist({
       <div className="max-w-md mx-auto text-center">
         <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
           <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
-          <p className="text-gray-300 text-sm mb-6">
+          <p className="text-sm mb-6">
             {joinedOutcome ? joinedSummary : waitlistIntro}
           </p>
           {joinedOutcome ? (
@@ -307,7 +305,7 @@ export default function WorkshopWaitlist({
               You&apos;re on the list
             </div>
           ) : (
-            <Button onClick={openModal} className={primaryButtonClass}>
+            <Button variant="primary" onClick={openModal}>
               Join Waitlist
             </Button>
           )}

--- a/src/components/workshop/WorkshopWaitlist.tsx
+++ b/src/components/workshop/WorkshopWaitlist.tsx
@@ -1,6 +1,6 @@
-import { useUser } from '@clerk/nextjs';
+import { useAuth, useUser, SignInButton } from '@clerk/nextjs';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, AlertCircle, CheckCircle, Mail } from 'lucide-react';
+import { X, AlertCircle, CheckCircle, Mail, DoorOpen, Clock } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -10,11 +10,25 @@ import useEvents from '@/hooks/useEvents';
 interface WorkshopWaitlistProps {
   workshopId: string;
   workshopTitle: string;
+  /**
+   * Number of seats still available in the room beyond the official cap.
+   * E.g. if the workshop sells 20 tickets but the room fits 25, and 0 people
+   * are already on the waitlist, this is 5. When > 0, the next signup is
+   * told they can show up at the door and pay in person.
+   */
+  overbookingSeatsAvailable: number;
 }
+
+type WaitlistOutcome = 'walk-in' | 'email-when-available';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export default function WorkshopWaitlist({ workshopId, workshopTitle }: WorkshopWaitlistProps) {
+export default function WorkshopWaitlist({
+  workshopId,
+  workshopTitle,
+  overbookingSeatsAvailable,
+}: WorkshopWaitlistProps) {
+  const { isSignedIn, isLoaded } = useAuth();
   const { user } = useUser();
   const { track } = useEvents();
 
@@ -23,9 +37,14 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
   const [name, setName] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isJoined, setIsJoined] = useState(false);
+  const [joinedOutcome, setJoinedOutcome] = useState<WaitlistOutcome | null>(null);
 
-  // Prefill form with Clerk user data when available
+  // The outcome the next signup will see, computed from the page-level
+  // overbookingSeatsAvailable count (manually maintained — see page config).
+  const nextOutcome: WaitlistOutcome =
+    overbookingSeatsAvailable > 0 ? 'walk-in' : 'email-when-available';
+
+  // Prefill from Clerk when user becomes available
   useEffect(() => {
     if (user) {
       if (!email && user.primaryEmailAddress) {
@@ -38,7 +57,7 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
-  // Close on escape
+  // Close on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setIsOpen(false);
@@ -48,14 +67,15 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
   }, [isOpen]);
 
   const openModal = () => {
-    track('waitlist_clicked', { workshop_id: workshopId });
+    track('waitlist_clicked', {
+      workshop_id: workshopId,
+      next_outcome: nextOutcome,
+    });
     setError(null);
     setIsOpen(true);
   };
 
-  const closeModal = () => {
-    setIsOpen(false);
-  };
+  const closeModal = () => setIsOpen(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,7 +93,7 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
       track('waitlist_submit_attempt', {
         workshop_id: workshopId,
         workshop_title: workshopTitle,
-        user_email: trimmedEmail,
+        outcome: nextOutcome,
       });
 
       const response = await fetch('/api/workshops/waitlist', {
@@ -84,6 +104,7 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
           workshopTitle,
           email: trimmedEmail,
           name: name.trim() || undefined,
+          outcome: nextOutcome,
         }),
       });
 
@@ -93,11 +114,11 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
         throw new Error(data.error || 'Failed to join the waitlist');
       }
 
-      setIsJoined(true);
+      setJoinedOutcome(nextOutcome);
       track('waitlist_joined', {
         workshop_id: workshopId,
         workshop_title: workshopTitle,
-        user_email: data.email,
+        outcome: nextOutcome,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to join the waitlist';
@@ -154,14 +175,38 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
 
             {/* Body */}
             <div className="p-5">
-              {isJoined ? (
-                <div className="text-center py-4">
+              {joinedOutcome === 'walk-in' ? (
+                <div className="text-center py-2">
                   <div className="mx-auto w-12 h-12 rounded-full bg-green-100 flex items-center justify-center mb-3">
-                    <CheckCircle className="h-6 w-6 text-green-600" />
+                    <DoorOpen className="h-6 w-6 text-green-600" />
                   </div>
-                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re on the list!</h3>
-                  <p className="text-sm text-gray-600 mb-5">
-                    We&apos;ll email <span className="font-medium">{email}</span> if a seat opens up for &quot;{workshopTitle}&quot;.
+                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re in — show up at the door!</h3>
+                  <p className="text-sm text-gray-700 mb-3">
+                    We have a small overbooking buffer and you fit in it. Just{' '}
+                    <span className="font-semibold">come to the workshop</span> and pay{' '}
+                    <span className="font-semibold">CHF 35 in cash on site</span>.
+                  </p>
+                  <p className="text-xs text-gray-500 mb-5">
+                    We&apos;ve also sent ourselves a note with your email{' '}
+                    (<span className="font-medium">{email}</span>) in case anything changes.
+                  </p>
+                  <Button
+                    onClick={closeModal}
+                    className="bg-black text-white px-5 py-2 rounded-lg font-semibold text-sm w-full"
+                  >
+                    Got it
+                  </Button>
+                </div>
+              ) : joinedOutcome === 'email-when-available' ? (
+                <div className="text-center py-2">
+                  <div className="mx-auto w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center mb-3">
+                    <Clock className="h-6 w-6 text-blue-600" />
+                  </div>
+                  <h3 className="text-lg font-bold text-black mb-2">You&apos;re on the waitlist</h3>
+                  <p className="text-sm text-gray-700 mb-5">
+                    The room is full. We&apos;ll email{' '}
+                    <span className="font-medium">{email}</span> if a seat opens up — usually
+                    a day or two before the workshop.
                   </p>
                   <Button
                     onClick={closeModal}
@@ -172,10 +217,43 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                 </div>
               ) : (
                 <>
-                  <p className="text-sm text-gray-600 mb-4">
-                    This workshop is sold out. Drop your email and we&apos;ll let you know if a spot opens up for{' '}
-                    <span className="font-semibold text-black">&quot;{workshopTitle}&quot;</span>.
-                  </p>
+                  {nextOutcome === 'walk-in' ? (
+                    <div className="bg-green-50 border border-green-200 rounded-lg p-3 mb-4 text-xs text-green-900 flex items-start gap-2">
+                      <DoorOpen className="h-4 w-4 mt-0.5 flex-shrink-0 text-green-600" />
+                      <span>
+                        Tickets are sold out, but we have room for a few more. If you sign up now,
+                        you can <span className="font-semibold">show up at the door and pay CHF 35 in cash</span>.
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4 text-xs text-blue-900 flex items-start gap-2">
+                      <Clock className="h-4 w-4 mt-0.5 flex-shrink-0 text-blue-600" />
+                      <span>
+                        The room is full. Drop your email and{' '}
+                        <span className="font-semibold">we&apos;ll reach out</span> if a seat opens up.
+                      </span>
+                    </div>
+                  )}
+
+                  {/* Sign-in option for guests */}
+                  {isLoaded && !isSignedIn && (
+                    <div className="bg-gray-50 border border-gray-200 rounded-lg p-3 mb-4 flex items-center justify-between gap-3">
+                      <span className="text-xs text-gray-700">
+                        Have an account? Sign in to use your saved email.
+                      </span>
+                      <SignInButton mode="modal">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            track('waitlist_signin_clicked', { workshop_id: workshopId })
+                          }
+                          className="text-xs font-semibold text-violet-700 hover:text-violet-900 whitespace-nowrap"
+                        >
+                          Sign in
+                        </button>
+                      </SignInButton>
+                    </div>
+                  )}
 
                   {error && (
                     <div className="bg-red-50 text-red-700 p-2 rounded-lg border border-red-200 text-xs mb-3 flex items-start">
@@ -198,7 +276,13 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                         placeholder="you@example.com"
                         required
                         autoFocus
+                        disabled={!!isSignedIn && !!user?.primaryEmailAddress}
                       />
+                      {isSignedIn && user?.primaryEmailAddress && (
+                        <p className="mt-1 text-[11px] text-gray-500">
+                          Using the email from your account.
+                        </p>
+                      )}
                     </div>
 
                     <div>
@@ -237,13 +321,15 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
                           </svg>
                           Joining...
                         </span>
+                      ) : nextOutcome === 'walk-in' ? (
+                        'Reserve my walk-in spot'
                       ) : (
-                        'Join the Waitlist'
+                        'Join the waitlist'
                       )}
                     </Button>
 
                     <p className="text-[11px] text-center text-gray-500">
-                      We&apos;ll only use your email to notify you about this workshop.
+                      We&apos;ll only use your email to contact you about this workshop.
                     </p>
                   </form>
                 </>
@@ -260,23 +346,33 @@ export default function WorkshopWaitlist({ workshopId, workshopTitle }: Workshop
       <div className="max-w-md mx-auto text-center">
         <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
           <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
-          <p className="text-gray-300 text-sm mb-6">
-            {isJoined
-              ? "You're on the waitlist — we'll be in touch if a spot opens up."
-              : "Join the waitlist and we'll notify you if a spot opens up."}
-          </p>
-          {isJoined ? (
-            <div className="bg-green-500/20 text-green-200 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
-              <CheckCircle size={16} />
-              You&apos;re on the list
-            </div>
+
+          {joinedOutcome ? (
+            <>
+              <p className="text-gray-300 text-sm mb-6">
+                {joinedOutcome === 'walk-in'
+                  ? "You're in — show up at the door and pay in cash."
+                  : "You're on the waitlist. We'll email you if a seat opens up."}
+              </p>
+              <div className="bg-green-500/20 text-green-200 border border-green-500/40 rounded-xl px-6 py-3 font-semibold text-sm flex items-center justify-center gap-2">
+                <CheckCircle size={16} />
+                You&apos;re on the list
+              </div>
+            </>
           ) : (
-            <Button
-              onClick={openModal}
-              className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
-            >
-              Join Waitlist
-            </Button>
+            <>
+              <p className="text-gray-300 text-sm mb-6">
+                {nextOutcome === 'walk-in'
+                  ? 'Tickets are sold out, but we have room for a few more — sign up to walk in and pay on site.'
+                  : "The room is full. Join the waitlist and we'll email you if a seat opens up."}
+              </p>
+              <Button
+                onClick={openModal}
+                className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
+              >
+                Join Waitlist
+              </Button>
+            </>
           )}
         </div>
       </div>

--- a/src/pages/api/workshops/waitlist.ts
+++ b/src/pages/api/workshops/waitlist.ts
@@ -1,0 +1,72 @@
+import { getAuth, clerkClient } from '@clerk/nextjs/server';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { sendPlatformNotification } from '@/lib/notification';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { workshopId, workshopTitle, email: bodyEmail, name: bodyName } = req.body || {};
+
+  if (!workshopId || !workshopTitle) {
+    return res.status(400).json({ error: 'Workshop ID and title are required' });
+  }
+
+  try {
+    // Try to resolve email/name from Clerk if the user is signed in
+    const { userId } = getAuth(req);
+
+    let email: string | undefined;
+    let name: string | undefined;
+    let source: 'authenticated' | 'guest' = 'guest';
+
+    if (userId) {
+      const client = await clerkClient();
+      const user = await client.users.getUser(userId);
+      email = user.primaryEmailAddress?.emailAddress;
+      name = user.firstName && user.lastName
+        ? `${user.firstName} ${user.lastName}`
+        : user.username || undefined;
+      source = 'authenticated';
+    }
+
+    // Fall back to body-provided email/name (for guests)
+    if (!email && typeof bodyEmail === 'string') {
+      email = bodyEmail.trim();
+    }
+    if (!name && typeof bodyName === 'string') {
+      const trimmed = bodyName.trim();
+      if (trimmed) name = trimmed;
+    }
+
+    if (!email || !EMAIL_REGEX.test(email)) {
+      return res.status(400).json({ error: 'A valid email is required to join the waitlist' });
+    }
+
+    const displayName = name || 'Guest';
+
+    await sendPlatformNotification({
+      title: 'New Workshop Waitlist Signup',
+      message: `${displayName} (${email}) joined the waitlist for "${workshopTitle}" (Workshop ID: ${workshopId}). Source: ${source}.`,
+      priority: 1,
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "You're on the waitlist! We'll email you if a spot opens up.",
+      email,
+      name: displayName,
+    });
+  } catch (error) {
+    console.error('Workshop waitlist signup error:', error);
+    return res.status(500).json({
+      error: 'Failed to join the waitlist. Please try again later.',
+    });
+  }
+}
+
+export default handler;

--- a/src/pages/api/workshops/waitlist.ts
+++ b/src/pages/api/workshops/waitlist.ts
@@ -5,19 +5,39 @@ import { sendPlatformNotification } from '@/lib/notification';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+type WaitlistOutcome = 'walk-in' | 'email-when-available';
+
+interface WaitlistRequestBody {
+  workshopId?: string;
+  workshopTitle?: string;
+  email?: string;
+  name?: string;
+  outcome?: WaitlistOutcome;
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { workshopId, workshopTitle, email: bodyEmail, name: bodyName } = req.body || {};
+  const {
+    workshopId,
+    workshopTitle,
+    email: bodyEmail,
+    name: bodyName,
+    outcome,
+  } = (req.body || {}) as WaitlistRequestBody;
 
   if (!workshopId || !workshopTitle) {
     return res.status(400).json({ error: 'Workshop ID and title are required' });
   }
 
+  if (outcome !== 'walk-in' && outcome !== 'email-when-available') {
+    return res.status(400).json({ error: 'Invalid waitlist outcome' });
+  }
+
   try {
-    // Try to resolve email/name from Clerk if the user is signed in
+    // If signed in via Clerk, prefer that email/name (more trustworthy)
     const { userId } = getAuth(req);
 
     let email: string | undefined;
@@ -34,7 +54,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       source = 'authenticated';
     }
 
-    // Fall back to body-provided email/name (for guests)
     if (!email && typeof bodyEmail === 'string') {
       email = bodyEmail.trim();
     }
@@ -48,18 +67,28 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     const displayName = name || 'Guest';
+    const outcomeLabel =
+      outcome === 'walk-in'
+        ? 'Walk-in (overbooking buffer) — told to show up & pay in person'
+        : 'Email when available — told we will reach out';
 
     await sendPlatformNotification({
       title: 'New Workshop Waitlist Signup',
-      message: `${displayName} (${email}) joined the waitlist for "${workshopTitle}" (Workshop ID: ${workshopId}). Source: ${source}.`,
+      message: [
+        `*Workshop:* ${workshopTitle} (${workshopId})`,
+        `*Name:* ${displayName}`,
+        `*Email:* ${email}`,
+        `*Source:* ${source}`,
+        `*Outcome shown to user:* ${outcomeLabel}`,
+      ].join('\n'),
       priority: 1,
     });
 
     return res.status(200).json({
       success: true,
-      message: "You're on the waitlist! We'll email you if a spot opens up.",
       email,
       name: displayName,
+      outcome,
     });
   } catch (error) {
     console.error('Workshop waitlist signup error:', error);

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -44,8 +44,21 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
     const workshopTime = '17:00 - 18:30 (1.5 hours)';
     const workshopLocation = 'Smallpdf AG, Zürich';
     const totalSeats = 20;
-    const seatsRemaining = 2;
+    const paidOrReservedSeats = 20;
+    const smallOverbookingLimit = 25;
+    const seatsRemaining = Math.max(totalSeats - paidOrReservedSeats, 0);
     const isSoldOut = seatsRemaining <= 0;
+    const shouldPayInPersonFromWaitlist = paidOrReservedSeats < smallOverbookingLimit;
+    const seatAvailabilityLabel = isSoldOut
+        ? 'Workshop sold out'
+        : `Only ${seatsRemaining} ${seatsRemaining === 1 ? 'seat' : 'seats'} available`;
+    const registrationHeading = isSoldOut ? 'Join the Waitlist' : 'Reserve Your Seat';
+    const registrationDetails = isSoldOut
+        ? shouldPayInPersonFromWaitlist
+            ? `Sold out at ${totalSeats} seats, but we can overbook up to ${smallOverbookingLimit}. Join the waitlist and pay in person · April 21, 2026 · 17:00–18:30 · ${workshopLocation}`
+            : `Sold out at ${totalSeats} seats. Join the waitlist and we will reach out by email if a spot opens up · April 21, 2026 · 17:00–18:30 · ${workshopLocation}`
+        : `${seatsRemaining} of ${totalSeats} seats remaining · April 21, 2026 · 17:00–18:30 · ${workshopLocation}`;
+    const primaryCtaLabel = isSoldOut ? 'Join Waitlist' : 'Reserve Your Seat — CHF 35';
 
     const topics = [
         {
@@ -309,7 +322,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                         <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4 text-center sm:text-left w-full sm:w-auto">
                             <div className="flex items-center gap-2">
                                 <Users size={18} className="text-white" />
-                                <span className="font-bold text-xs sm:text-sm">Only {seatsRemaining} seats available!</span>
+                                <span className="font-bold text-xs sm:text-sm">{seatAvailabilityLabel}</span>
                             </div>
                             <div className="hidden sm:block h-6 w-px bg-white/30"></div>
                             <div className="flex items-center gap-2">
@@ -375,8 +388,10 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                                     </div>
                                     <div className="bg-white rounded-xl p-4 shadow-sm border border-black/10 flex flex-col justify-center items-center text-center min-h-[80px]">
                                         <Users size={20} className="text-zurich mb-1" />
-                                        <div className="text-xs font-bold text-black">{totalSeats} seats</div>
-                                        <div className="text-xs text-gray-600">Limited</div>
+                                        <div className="text-xs font-bold text-black">
+                                            {isSoldOut ? 'Sold out' : `${seatsRemaining} left`}
+                                        </div>
+                                        <div className="text-xs text-gray-600">{totalSeats} seats</div>
                                     </div>
                                     <div className="bg-white rounded-xl p-4 shadow-sm border border-black/10 flex flex-col justify-center items-center text-center min-h-[80px]">
                                         <div className="text-2xl font-black text-black mb-1">35</div>
@@ -386,24 +401,24 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
 
                                 <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                                     <Button
+                                        variant="primary"
                                         onClick={scrollToRegistration}
-                                        className="bg-black text-js font-bold px-6 py-3 rounded-xl hover:bg-gray-900 transition-colors text-sm sm:text-base"
                                     >
-                                        {isSoldOut ? 'Join Waitlist' : 'Reserve Your Seat — CHF 35'}
+                                        {primaryCtaLabel}
                                     </Button>
-                                    <button
+                                    <Button
+                                        variant="outline"
                                         onClick={scrollToDetails}
-                                        className="bg-white text-black font-bold px-6 py-3 rounded-xl border-2 border-black hover:bg-gray-50 transition-colors text-sm sm:text-base"
                                     >
                                         Learn More
-                                    </button>
-                                    <button
+                                    </Button>
+                                    <Button
+                                        variant="outline"
                                         onClick={shareWorkshop}
-                                        className="flex items-center justify-center gap-2 bg-white/80 text-black px-4 py-3 rounded-xl border-2 border-black/20 hover:bg-white transition-colors"
                                         aria-label="Share this workshop"
                                     >
                                         <Share2 size={18} />
-                                    </button>
+                                    </Button>
                                 </div>
                             </div>
 
@@ -638,7 +653,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
             </Section>
 
             {/* Ticket / Registration Section */}
-            <Section className="bg-black text-white" id="registrationContainer">
+            <Section className="bg-black" id="registrationContainer">
                 <div className="container mx-auto px-4 py-12 lg:py-16">
                     <motion.div
                         initial={{ opacity: 0, y: 20 }}
@@ -647,9 +662,9 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                         viewport={{ once: true }}
                         className="text-center mb-10"
                     >
-                        <h2 className="text-3xl font-black text-white mb-4">Reserve Your Seat</h2>
-                        <p className="text-black max-w-xl mx-auto">
-                            {totalSeats} spots available · April 21, 2026 · 17:00–18:30 · {workshopLocation}
+                        <h2 className="text-3xl font-black  mb-4">{registrationHeading}</h2>
+                        <p className="max-w-xl mx-auto">
+                            {registrationDetails}
                         </p>
                     </motion.div>
 
@@ -660,7 +675,12 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                     )}
 
                     {isSoldOut ? (
-                        <WorkshopWaitlist workshopId={workshopId} workshopTitle={workshopTitle} />
+                        <WorkshopWaitlist
+                            workshopId={workshopId}
+                            workshopTitle={workshopTitle}
+                            shouldPayInPerson={shouldPayInPersonFromWaitlist}
+                            overbookingLimit={smallOverbookingLimit}
+                        />
                     ) : (
                         <div className="max-w-2xl mx-auto">
                             <TicketSelection
@@ -725,10 +745,10 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                         Join Davy on April 21st and leave with a clear mental model for building reliable, production-ready AI agents.
                     </p>
                     <Button
+                        variant="primary"
                         onClick={scrollToRegistration}
-                        className="bg-black text-js font-bold px-8 py-3 rounded-xl hover:bg-gray-900 transition-colors"
                     >
-                        Reserve Your Seat — CHF 35
+                        {primaryCtaLabel}
                     </Button>
                 </div>
             </Section>

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -12,6 +12,7 @@ import Button from '@/components/ui/Button';
 import CancelledCheckout from '@/components/workshop/CancelledCheckout';
 import { reliableAiAgentsTickets } from '@/components/workshop/reliableAiAgentsTickets';
 import TicketSelection from '@/components/workshop/TicketSelection';
+import WorkshopWaitlist from '@/components/workshop/WorkshopWaitlist';
 import { useAuthenticatedCheckout } from '@/hooks/useAuthenticatedCheckout';
 import { useCoupon } from '@/hooks/useCoupon';
 import useEvents from '@/hooks/useEvents';
@@ -659,18 +660,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                     )}
 
                     {isSoldOut ? (
-                        <div className="max-w-md mx-auto text-center">
-                            <div className="bg-white/10 rounded-2xl p-8 border border-white/20">
-                                <h3 className="text-xl font-bold text-white mb-3">Workshop Sold Out</h3>
-                                <p className="text-gray-300 text-sm mb-6">Join the waitlist and we&apos;ll notify you if a spot opens up.</p>
-                                <Button
-                                    onClick={() => track('waitlist_clicked', { workshop_id: workshopId })}
-                                    className="bg-js text-black font-bold px-6 py-3 rounded-xl hover:bg-yellow-400 transition-colors w-full"
-                                >
-                                    Join Waitlist
-                                </Button>
-                            </div>
-                        </div>
+                        <WorkshopWaitlist workshopId={workshopId} workshopTitle={workshopTitle} />
                     ) : (
                         <div className="max-w-2xl mx-auto">
                             <TicketSelection

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -666,7 +666,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                         whileInView={{ opacity: 1, y: 0 }}
                         transition={{ duration: 0.5 }}
                         viewport={{ once: true }}
-                        className="text-center mb-10"
+                        className="text-center"
                     >
                         <h2 className="text-3xl font-black  mb-4">{registrationHeading}</h2>
                         <p className="max-w-xl mx-auto">
@@ -675,7 +675,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                     </motion.div>
 
                     {router.isReady && canceled && (
-                        <div className="max-w-2xl mx-auto mb-8">
+                        <div className="max-w-2xl mx-auto mt-10 mb-8">
                             <CancelledCheckout workshopId={workshopId} workshopTitle={workshopTitle} />
                         </div>
                     )}
@@ -687,7 +687,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                             overbookingSeatsAvailable={overbookingSeatsAvailable}
                         />
                     ) : (
-                        <div className="max-w-2xl mx-auto">
+                        <div className="max-w-2xl mx-auto mt-10">
                             <TicketSelection
                                 options={reliableAiAgentsTickets}
                                 onCheckout={handleCheckout}

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -44,7 +44,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
     const workshopTime = '17:00 - 18:30 (1.5 hours)';
     const workshopLocation = 'Smallpdf AG, Zürich';
     const totalSeats = 20;
-    const paidOrReservedSeats = 20;
+    const paidOrReservedSeats = 17;
     const physicalCapacity = 25;
     // Bump this manually after each waitlist signup that is told to show up and pay in person.
     const currentWalkInWaitlistCount = 0;

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -47,6 +47,20 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
     const seatsRemaining = 2;
     const isSoldOut = seatsRemaining <= 0;
 
+    // Waitlist / overbooking config
+    // - `physicalCapacity` is the absolute number of bodies the room can fit.
+    // - `currentWaitlistCount` is bumped manually after each Pushover signup
+    //   ping (same pattern we use for `seatsRemaining`).
+    // While `overbookingSeatsAvailable > 0`, the next waitlist signup is
+    // told to show up at the door and pay CHF 35 in cash. Once that buffer
+    // is exhausted, signups are told we'll email them if a seat opens up.
+    const physicalCapacity = 25;
+    const currentWaitlistCount = 0;
+    const overbookingSeatsAvailable = Math.max(
+        0,
+        physicalCapacity - totalSeats - currentWaitlistCount
+    );
+
     const topics = [
         {
             title: 'What AI Agents Are',
@@ -660,7 +674,11 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
                     )}
 
                     {isSoldOut ? (
-                        <WorkshopWaitlist workshopId={workshopId} workshopTitle={workshopTitle} />
+                        <WorkshopWaitlist
+                            workshopId={workshopId}
+                            workshopTitle={workshopTitle}
+                            overbookingSeatsAvailable={overbookingSeatsAvailable}
+                        />
                     ) : (
                         <div className="max-w-2xl mx-auto">
                             <TicketSelection

--- a/src/pages/workshops/reliable-ai-agents.tsx
+++ b/src/pages/workshops/reliable-ai-agents.tsx
@@ -44,7 +44,7 @@ export default function ReliableAiAgentsWorkshopPage({ speakers }: WorkshopPageP
     const workshopTime = '17:00 - 18:30 (1.5 hours)';
     const workshopLocation = 'Smallpdf AG, Zürich';
     const totalSeats = 20;
-    const paidOrReservedSeats = 17;
+    const paidOrReservedSeats = 20;
     const physicalCapacity = 25;
     // Bump this manually after each waitlist signup that is told to show up and pay in person.
     const currentWalkInWaitlistCount = 0;


### PR DESCRIPTION
When the AI agents workshop reaches capacity, visitors can now drop their
email into a waitlist modal. Submitting fires a Slack/Pushover notification
with the joiner's email, name, and workshop, so we can reach back out if a
seat frees up.

- New POST /api/workshops/waitlist endpoint accepts { workshopId,
  workshopTitle, email, name }, validates the email, and uses Clerk auth
  details when the user is signed in.
- New WorkshopWaitlist component renders the sold-out card plus an email
  modal (prefilled from Clerk) and shows a confirmation state after
  signup.
- Wired into the reliable-ai-agents page in place of the previous
  no-op "Join Waitlist" button.